### PR TITLE
PIZ1 - I can not create an order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,5 @@ test:
 	python3 manage.py test
 
 start:
-	FLASK_ENV=development
-	python3 manage.py run 
+	FLASK_ENV=development python3 manage.py run 
 

--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_all_sizes():
+    sizes,error=SizeController.get_all()
+    response= sizes if not error else {'error':error}
+    status_code=200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,0 +1,8 @@
+import pytest
+
+def test_get_all_size_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {size['_id']:size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
Ticket Link:

[Link](https://trello.com/c/npemRCog/1-piz1-i-cant-create-an-order-bug)

Description:

During the order creation, the user wasn't able to see the pizza sizes and therefore create the order. Because of that, an endpoint to be able to get the pizza sizes was created.

Screenshots:

![image](https://github.com/Csmolina/python-pizza-planet/assets/58301825/800844f7-da78-4eab-aa20-cd4f4b6615f0)



